### PR TITLE
Dotnet6 upgrade with workaround

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -17,6 +17,17 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.100-preview.1.21103.13
+    - name: Build automated tests
+      run: dotnet build UserSecrets/UserSecrets.Tests/UserSecrets.Tests.csproj --configuration Release
+    - name: Create empty file to get around error in .NET 6
+      run: |
+        #Create the secrets.json file
+        New-Item UserSecrets\UserSecrets.Tests\secrets.json
+        #Insert in empty braces to make it a valid (empty) json file
+        "{}" | Set-Content UserSecrets\UserSecrets.Tests\secrets.json
+        #Copy the secrets.json file to the bin directory, so that it will be present for the tests 
+        xcopy "${{ github.workspace }}\UserSecrets\UserSecrets.Tests\secrets.json" "${{ github.workspace }}\UserSecrets\UserSecrets.Tests\bin\release\net6.0\"  /f /y
+      shell: powershell
     - name: Run automated unit and integration tests
       run: dotnet test UserSecrets/UserSecrets.Tests/UserSecrets.Tests.csproj --configuration Release
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.100-preview.1.21103.13
     - name: Run automated unit and integration tests
       run: dotnet test UserSecrets/UserSecrets.Tests/UserSecrets.Tests.csproj --configuration Release
 

--- a/UserSecrets/UserSecrets.Tests/UserSecrets.Tests.csproj
+++ b/UserSecrets/UserSecrets.Tests/UserSecrets.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -13,9 +13,9 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0-preview.1.21102.12" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0-preview.1.21102.12" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0-preview.1.21102.12" />
 
   </ItemGroup>
 


### PR DESCRIPTION
this one succeeds, as I created a workaround to create an empty json doc secrets.json, and copy it to the bin folder.